### PR TITLE
⚰ Remove column description

### DIFF
--- a/Final_Project-P4DS.ipynb
+++ b/Final_Project-P4DS.ipynb
@@ -405,20 +405,7 @@
    "cell_type": "markdown",
    "id": "e755c455",
    "metadata": {},
-   "source": [
-    "* `location`: name of the country (or region within a country).\n",
-    "* `iso_code`: ISO 3166-1 alpha-3 – three-letter country codes.\n",
-    "* `date`: date of the observation.\n",
-    "* `total_vaccinations`: total number of doses administered. This is counted as a single dose, and may not equal the total number of people vaccinated, depending on the specific dose regime (e.g. people receive multiple doses). If a person receives one dose of the vaccine, this metric goes up by 1. If they receive a second dose, it goes up by 1 again.\n",
-    "* `total_vaccinations_per_hundred`: `total_vaccinations` per 100 people in the total population of the country.\n",
-    "* `daily_vaccinations_raw`: daily change in the total number of doses administered. It is only calculated for consecutive days. This is a raw measure provided for data checks and transparency, but we strongly recommend that any analysis on daily vaccination rates be conducted using `daily_vaccinations` instead.\n",
-    "* `daily_vaccinations`: new doses administered per day (7-day smoothed). For countries that don't report data on a daily basis, we assume that doses changed equally on a daily basis over any periods in which no data was reported. This produces a complete series of daily figures, which is then averaged over a rolling 7-day window. An example of how we perform this calculation can be found [here](https://github.com/owid/covid-19-data/issues/333#issuecomment-763015298).\n",
-    "* `daily_vaccinations_per_million`: `daily_vaccinations` per 1,000,000 people in the total population of the country.\n",
-    "* `people_vaccinated`: total number of people who received at least one vaccine dose. If a person receives the first dose of a 2-dose vaccine, this metric goes up by 1. If they receive the second dose, the metric stays the same.\n",
-    "* `people_vaccinated_per_hundred`: `people_vaccinated` per 100 people in the total population of the country.\n",
-    "* `people_fully_vaccinated`: total number of people who received all doses prescribed by the vaccination protocol. If a person receives the first dose of a 2-dose vaccine, this metric stays the same. If they receive the second dose, the metric goes up by 1.\n",
-    "* `people_fully_vaccinated_per_hundred`: `people_fully_vaccinated` per 100 people in the total population of the country."
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
- This section belonged to Trieu